### PR TITLE
chore: upgrade remote-state to v2.0.0

### DIFF
--- a/src/remote-state.tf
+++ b/src/remote-state.tf
@@ -2,7 +2,7 @@ module "requester_vpc" {
   count = var.requester_vpc_id == null ? 1 : 0
 
   source  = "cloudposse/stack-config/yaml//modules/remote-state"
-  version = "1.8.0"
+  version = "2.0.0"
 
   component = var.requester_vpc_component_name
 

--- a/src/versions.tf
+++ b/src/versions.tf
@@ -6,5 +6,9 @@ terraform {
       source  = "hashicorp/aws"
       version = ">= 3.0, < 6.0.0"
     }
+    utils = {
+      source  = "cloudposse/utils"
+      version = ">= 2.0.0, < 3.0.0"
+    }
   }
 }

--- a/test/fixtures/vendor.yaml
+++ b/test/fixtures/vendor.yaml
@@ -6,8 +6,8 @@ metadata:
 spec:
   sources:
     - component: "account-map"
-      source: github.com/cloudposse/terraform-aws-components.git//modules/account-map?ref={{.Version}}
-      version: 1.520.0
+      source: github.com/cloudposse-terraform-components/aws-account-map.git//src?ref={{.Version}}
+      version: v1.537.2
       targets:
         - "components/terraform/account-map"
       included_paths:
@@ -19,7 +19,7 @@ spec:
 
     - component: "vpc"
       source: github.com/cloudposse-terraform-components/aws-vpc.git//src?ref={{.Version}}
-      version: v1.536.0
+      version: v2.1.2
       targets:
         - "components/terraform/vpc"
       included_paths:


### PR DESCRIPTION
## Summary
- Upgrade `cloudposse/stack-config/yaml//modules/remote-state` from v1.x to v2.0.0
- Add `cloudposse/utils` provider constraint `>= 2.0.0, < 3.0.0`
- Update vendored dependency versions to releases with remote-state v2.0.0

## Test plan
- [ ] CI lint passes
- [ ] Terratest passes in merge queue

🤖 Generated with [Claude Code](https://claude.com/claude-code)